### PR TITLE
Fix a spelling attribute error

### DIFF
--- a/apps/web/content/docs/concepts/annotations.mdx
+++ b/apps/web/content/docs/concepts/annotations.mdx
@@ -145,7 +145,7 @@ import { InnerPre, getPreRef } from "codehike/code"
 
 const myHandler: AnnotationHandler = {
   Pre: (props) => (
-    <InnerPre merge={props} classname="rounded border border-blue-100" />
+    <InnerPre merge={props} className="rounded border border-blue-100" />
   ),
   // If you need the ref to the pre element, use PreWithRef:
   PreWithRef: (props) => {


### PR DESCRIPTION
When I followed the doc and tried the solution, I found there was an error from TypeScript.

```
Type '{ merge: CustomPreProps; classname: string; }' is not assignable to type 'IntrinsicAttributes & { merge: CustomPreProps; } & Partial<CustomPreProps>'.
  Property 'classname' does not exist on type 'IntrinsicAttributes & { merge: CustomPreProps; } & Partial<CustomPreProps>'. Did you mean 'className'?ts(2322)
```

To fix this error, just replace classname with className.